### PR TITLE
Add an option to test a feature view on the atomic events table

### DIFF
--- a/examples/web_stream_feature_view.ipynb
+++ b/examples/web_stream_feature_view.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Stream features from Web events using Signals\n",
+    "\n",
+    "This notebook creates a new feature view using the SDK, tests it on the atomic events table and applies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Flow of data\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    sp(Snowplow Pipeline)\n",
+    "    stream[/Stream processing/]\n",
+    "    signals(Signals)\n",
+    "\n",
+    "    sp --> stream\n",
+    "    stream --> signals\n",
+    "```\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from snowplow_signals import Signals\n",
+    "\n",
+    "sp_signals = Signals()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define a new feature\n",
+    "\n",
+    "This block creates a single feature definition including the logic how it should be calculated (it's filters and aggregation).\n",
+    "\n",
+    "The feature calculates the number of add to cart ecommerce events."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from snowplow_signals import (\n",
+    "    Feature,\n",
+    "    FilterCombinator,\n",
+    "    FilterCondition,\n",
+    ")\n",
+    "\n",
+    "count_page_pings_feature = Feature(\n",
+    "    name=\"count_page_pings\",\n",
+    "    scope=\"session\",\n",
+    "    dtype=\"INT32\",\n",
+    "    events=[\n",
+    "        \"iglu:com.snowplowanalytics.snowplow/page_ping/jsonschema/1-0-0\"\n",
+    "    ],\n",
+    "    type=\"counter\",\n",
+    ")\n",
+    "\n",
+    "visited_pages_feature = Feature(\n",
+    "    name=\"visited_pages\",\n",
+    "    scope=\"session\",\n",
+    "    dtype=\"STRING_LIST\",\n",
+    "    events=[\n",
+    "        \"iglu:com.snowplowanalytics.snowplow/page_view/jsonschema/1-0-0\"\n",
+    "    ],\n",
+    "    type=\"unique_list\",\n",
+    "    property=\"page_title\",\n",
+    ")\n",
+    "\n",
+    "clicked_links_on_homepage_feature = Feature(\n",
+    "    name=\"clicked_links\",\n",
+    "    scope=\"session\",\n",
+    "    dtype=\"STRING_LIST\",\n",
+    "    events=[\n",
+    "        \"iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1\"\n",
+    "    ],\n",
+    "    type=\"unique_list\",\n",
+    "    property=\"unstruct_event_com_snowplowanalytics_snowplow_link_click_1:targetUrl\",\n",
+    "    filter=FilterCombinator(\n",
+    "        combinator=\"and\",\n",
+    "        condition=[\n",
+    "            FilterCondition(\n",
+    "                property=\"page_urlpath\",\n",
+    "                operator=\"equals\",\n",
+    "                value=\"/\",\n",
+    "            ),\n",
+    "        ],\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Wrapping the feature in a feature view\n",
+    "\n",
+    "All features need to be included in feature views that can be considered as \"tables\" of features.\n",
+    "\n",
+    "Feature views are immutable and versioned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from snowplow_signals import FeatureView, session_entity\n",
+    "\n",
+    "feature_view = FeatureView(\n",
+    "    name=\"my_web_features\",\n",
+    "    version=1,\n",
+    "    entities=[\n",
+    "        session_entity,\n",
+    "    ],\n",
+    "    features=[\n",
+    "        count_page_pings_feature,\n",
+    "        visited_pages_feature,\n",
+    "        clicked_links_on_homepage_feature,\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Testing the feature view\n",
+    "\n",
+    "Execute the feature view on the last one hour of data from the atomic events table to verify that it works correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = sp_signals.test(\n",
+    "    feature_view=feature_view,\n",
+    "    app_ids=[\"website\"],\n",
+    ")\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Applying the feature view to Signals\n",
+    "\n",
+    "The following block pushes the feature view definition to the Signals API and makes it available for processing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from snowplow_signals import Signals\n",
+    "\n",
+    "sp_signals = Signals()\n",
+    "sp_signals.apply([feature_view])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "snowplow-signals-DQcgxUvJ-py3.13",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/snowplow_signals/models/test_feature_view.py
+++ b/src/snowplow_signals/models/test_feature_view.py
@@ -1,0 +1,11 @@
+from datetime import timedelta
+
+from pydantic import BaseModel
+from .feature_view import FeatureView
+
+
+class TestFeatureViewRequest(BaseModel):
+    feature_view: FeatureView
+    app_ids: list[str] = []
+    window: timedelta = timedelta(hours=1)
+    entity_ids: list[str]

--- a/src/snowplow_signals/signals.py
+++ b/src/snowplow_signals/signals.py
@@ -1,4 +1,6 @@
 from typing import Literal, Optional, Union
+from datetime import timedelta
+import pandas as pd
 
 from pydantic import BaseModel
 
@@ -7,6 +9,7 @@ from .models.base_signals_object import BaseSignalsObject
 from .models.feature_service import FeatureService
 from .models.feature_view import FeatureView
 from .models.online_features import GetOnlineFeatureResponse, GetOnlineFeaturesRequest
+from .models.test_feature_view import TestFeatureViewRequest
 from .prompts.client import PromptsClient
 
 
@@ -73,3 +76,33 @@ class Signals:
             data=data.model_dump(mode="json"),
         )
         return GetOnlineFeatureResponse(data=response) if response else None
+
+    def test(
+        self,
+        feature_view: FeatureView,
+        entity_ids: list[str] = [],
+        app_ids: list[str] = [],
+        window: timedelta = timedelta(hours=1),
+    ) -> pd.DataFrame:
+        """
+        Tests the feature view by extracting the features from the latest window of events in the atomic events table in warehouse.
+
+        Args:
+            feature_view: The feature view to test.
+            entity_ids: The list of entity ids (e.g., domain_userid values) to extract features for. If empty, random 10 IDs will be used.
+            app_ids: The list of app ids to extract features for.
+            window: The time window to extract features from.
+        """
+        request = TestFeatureViewRequest(
+            feature_view=feature_view,
+            entity_ids=entity_ids,
+            window=window,
+            app_ids=app_ids,
+        )
+
+        data = self.api_client.make_post_request(
+            endpoint="testing/feature_views/",
+            data=request.model_dump(mode="json"),
+        )
+
+        return pd.DataFrame(data)


### PR DESCRIPTION
Exposes the test functionality implemented [in this PR](https://github.com/snowplow-incubator/signals-personalization-api/pull/23) in the API from the SDK.