### PR TITLE
Increase request timeout to 30s

### DIFF
--- a/src/snowplow_signals/api_client.py
+++ b/src/snowplow_signals/api_client.py
@@ -29,6 +29,7 @@ class ApiClient:
             headers=self._get_headers(),
             params=params,
             json=data,
+            timeout=30.0,
         )
 
         if response.status_code in (200, 201):


### PR DESCRIPTION
The default request timeout was around 5 seconds which is not enough for some requests such as calling `/feature_store/apply` to apply to Feast – that may take around 10-20 seconds. Also the request for testing a feature view that runs a query on the atomic events table tends to take more than 5 seconds.

I have increased the timeout for all requests to 30 seconds. If it's preferable, we can have per-request timeout configs.