### PR TITLE
Fix serializing period in Views

### DIFF
--- a/src/snowplow_signals/registry_client.py
+++ b/src/snowplow_signals/registry_client.py
@@ -4,13 +4,12 @@ from .models import View, ViewOutput, Service
 
 # TODO: When PUT endponts are available in the registry API, update existing objects with the input.
 
+
 class RegistryClient:
     def __init__(self, api_client: ApiClient):
         self.api_client = api_client
 
-    def apply(
-        self, objects: list[View | Service]
-    ) -> list[ViewOutput | Service]:
+    def apply(self, objects: list[View | Service]) -> list[ViewOutput | Service]:
         updated_objects: list[View | Service] = []
 
         # First apply all views in case they are dependencies of services
@@ -29,7 +28,7 @@ class RegistryClient:
             response = self.api_client.make_request(
                 method="POST",
                 endpoint="registry/views/",
-                data=view.model_dump(exclude_none=True),
+                data=view.model_dump(mode="json", exclude_none=True),
             )
         except SignalsAPIError as e:
             if e.status_code == 400:
@@ -47,7 +46,7 @@ class RegistryClient:
             response = self.api_client.make_request(
                 method="POST",
                 endpoint="registry/services/",
-                data=service.model_dump(exclude_none=True),
+                data=service.model_dump(mode="json", exclude_none=True),
             )
         except SignalsAPIError as e:
             if e.status_code == 400:

--- a/test/test_registry_client.py
+++ b/test/test_registry_client.py
@@ -1,0 +1,50 @@
+import httpx
+from datetime import timedelta
+
+from snowplow_signals import View, user_entity, LinkEntity, Attribute, Event
+from snowplow_signals.models import ViewOutput
+from snowplow_signals.api_client import ApiClient
+from snowplow_signals.registry_client import RegistryClient
+
+
+class TestRegistryClient:
+
+    def test_serializes_period_correctly_using_iso_format(self, respx_mock):
+        view = View(
+            name="my_view",
+            entity=user_entity,
+            attributes=[
+                Attribute(
+                    name="add_to_cart_events_count",
+                    type="int32",
+                    events=[
+                        Event(
+                            vendor="com.snowplowanalytics.snowplow.ecommerce",
+                            name="snowplow_ecommerce_action",
+                            version="1-0-2",
+                        )
+                    ],
+                    aggregation="counter",
+                    period=timedelta(days=1),
+                )
+            ],
+        )
+        view_output = ViewOutput(
+            name="my_view",
+            entity=LinkEntity(name="user"),
+            feast_name="my_view_v1",
+            offline=True,
+            stream_source_name="my_stream",
+            entity_key="user_id",
+        )
+
+        view_mock = respx_mock.post(
+            "http://localhost:8000/api/v1/registry/views/"
+        ).mock(return_value=httpx.Response(201, json=view_output.model_dump()))
+
+        api_client = ApiClient(api_url="http://localhost:8000")
+        registry_client = RegistryClient(api_client=api_client)
+        registry_client.apply([view])
+
+        assert view_mock.called
+        assert "P1D" in str(view_mock.calls[0].request.content)


### PR DESCRIPTION
Add missing `mode="json"` attribute when calling `model_dump()` on pydantic views which takes care of serializing timedelta and other objects that Python can't serialize well itself.