### PR TITLE
Add syntax sugar for working with criteria

### DIFF
--- a/src/snowplow_signals/__init__.py
+++ b/src/snowplow_signals/__init__.py
@@ -1,6 +1,7 @@
 from snowplow_signals.models import (
     Attribute,
     BatchSource,
+    Column,
     Criteria,
     Criterion,
     Entity,
@@ -11,8 +12,15 @@ from snowplow_signals.models import (
     View,
 )
 from snowplow_signals.signals import Signals
-from .definitions import session_entity, user_entity, domain_userid, domain_sessionid, user_id, network_userid
 
+from .definitions import (
+    domain_sessionid,
+    domain_userid,
+    network_userid,
+    session_entity,
+    user_entity,
+    user_id,
+)
 
 Signals
 View
@@ -25,6 +33,7 @@ BatchSource
 Entity
 LinkEntity
 Event
+Column
 user_entity
 session_entity
 domain_userid

--- a/src/snowplow_signals/models/__init__.py
+++ b/src/snowplow_signals/models/__init__.py
@@ -1,24 +1,25 @@
+from .columns import Column
 from .model import AttributeInput as Attribute
 from .model import (
     AttributeOutput,
     BatchSource,
-    Criteria,
-    Criterion,
     Entity,
     Event,
-    LinkEntity,
 )
 from .model import FieldModel as Field
 from .model import (
     GetOnlineAttributesRequest,
+    LinkEntity,
     TestViewRequest,
     ViewResponse,
 )
 from .online_attributes_response import OnlineAttributesResponse
 from .service import Service
 from .view import View
+from .wrappers.criteria import Criteria, Criterion
 
 AttributeOutput
+Column
 Criteria
 Criterion
 View

--- a/src/snowplow_signals/models/columns.py
+++ b/src/snowplow_signals/models/columns.py
@@ -1,0 +1,265 @@
+from functools import wraps
+from re import sub
+from typing import Literal, TypeAlias
+
+from pydantic import BaseModel, Field, RootModel
+
+from .wrappers.criteria import Criteria, Criterion
+
+AtomicField: TypeAlias = Literal[
+    "app_id",
+    "platform",
+    "etl_tstamp",
+    "collector_tstamp",
+    "dvce_created_tstamp",
+    "event",
+    "event_id",
+    "txn_id",
+    "name_tracker",
+    "v_tracker",
+    "v_collector",
+    "v_etl",
+    "user_id",
+    "user_ipaddress",
+    "user_fingerprint",
+    "domain_userid",
+    "domain_sessionidx",
+    "network_userid",
+    "geo_country",
+    "geo_region",
+    "geo_city",
+    "geo_zipcode",
+    "geo_latitude",
+    "geo_longitude",
+    "geo_region_name",
+    "ip_isp",
+    "ip_organization",
+    "ip_domain",
+    "ip_netspeed",
+    "page_url",
+    "page_title",
+    "page_referrer",
+    "page_urlscheme",
+    "page_urlhost",
+    "page_urlport",
+    "page_urlpath",
+    "page_urlquery",
+    "page_urlfragment",
+    "refr_urlscheme",
+    "refr_urlhost",
+    "refr_urlport",
+    "refr_urlpath",
+    "refr_urlquery",
+    "refr_urlfragment",
+    "refr_medium",
+    "refr_source",
+    "refr_term",
+    "mkt_medium",
+    "mkt_source",
+    "mkt_term",
+    "mkt_content",
+    "mkt_campaign",
+    "contexts",
+    "se_category",
+    "se_action",
+    "se_label",
+    "se_property",
+    "se_value",
+    "unstruct_event",
+    "tr_orderid",
+    "tr_affiliation",
+    "tr_total",
+    "tr_tax",
+    "tr_shipping",
+    "tr_city",
+    "tr_state",
+    "tr_country",
+    "ti_orderid",
+    "ti_sku",
+    "ti_name",
+    "ti_category",
+    "ti_price",
+    "ti_quantity",
+    "pp_xoffset_min",
+    "pp_xoffset_max",
+    "pp_yoffset_min",
+    "pp_yoffset_max",
+    "useragent",
+    "br_name",
+    "br_family",
+    "br_version",
+    "br_type",
+    "br_renderengine",
+    "br_lang",
+    "br_features_pdf",
+    "br_features_flash",
+    "br_features_java",
+    "br_features_director",
+    "br_features_quicktime",
+    "br_features_realplayer",
+    "br_features_windowsmedia",
+    "br_features_gears",
+    "br_features_silverlight",
+    "br_cookies",
+    "br_colordepth",
+    "br_viewwidth",
+    "br_viewheight",
+    "os_name",
+    "os_family",
+    "os_manufacturer",
+    "os_timezone",
+    "dvce_type",
+    "dvce_ismobile",
+    "dvce_screenwidth",
+    "dvce_screenheight",
+    "doc_charset",
+    "doc_width",
+    "doc_height",
+    "tr_currency",
+    "tr_total_base",
+    "tr_tax_base",
+    "tr_shipping_base",
+    "ti_currency",
+    "ti_price_base",
+    "base_currency",
+    "geo_timezone",
+    "mkt_clickid",
+    "mkt_network",
+    "etl_tags",
+    "dvce_sent_tstamp",
+    "refr_domain_userid",
+    "refr_device_tstamp",
+    "derived_contexts",
+    "domain_sessionid",
+    "derived_tstamp",
+    "event_vendor",
+    "event_name",
+    "event_format",
+    "event_version",
+    "event_fingerprint",
+    "true_tstamp",
+]
+
+
+def _clean_vendor(vendor: str) -> str:
+    # see https://github.com/snowplow/snowplow-python-analytics-sdk/blob/0ddca91e3f6d8bed88627fa557790aa4868bdace/snowplow_analytics_sdk/json_shredder.py#L64
+    return vendor.replace(".", "_").lower()
+
+
+def _clean_name(name: str) -> str:
+    # see https://github.com/snowplow/snowplow-python-analytics-sdk/blob/0ddca91e3f6d8bed88627fa557790aa4868bdace/snowplow_analytics_sdk/json_shredder.py#L65
+    return sub(r"([^A-Z_])([A-Z])", r"\g<1>_\g<2>", name).lower()
+
+
+def _clean_version(version: str | int) -> str:
+    # see https://github.com/snowplow/snowplow-python-analytics-sdk/blob/0ddca91e3f6d8bed88627fa557790aa4868bdace/snowplow_analytics_sdk/json_shredder.py#L66
+    return str(version) if isinstance(version, int) else version.partition("-")[0]
+
+
+def _default_criteria(
+    property: str, operator, other: str | int | float | bool | list
+) -> Criteria:
+    return Criteria(
+        all=[
+            Criterion(
+                property=property,
+                operator=operator,
+                value=other,
+                property_syntax="snowflake",
+            ),
+        ],
+        any=None,
+    )
+
+
+class EntityProperty(BaseModel):
+    """Reference a nested property from an entity field from the event context."""
+
+    vendor: str
+    name: str
+    path: str = ""
+    version: str | int = Field(default=1, pattern=r"^\d+-\d+-\d+$")
+    index: int = 0
+
+    def __str__(self) -> str:
+        path = "" if not self.path else f".{self.path}"
+        return f"contexts_{_clean_vendor(self.vendor)}_{_clean_name(self.name)}_{_clean_version(self.version)}[{self.index}]{path}"
+
+
+class SelfDescProperty(BaseModel):
+    """Reference a nested property from a Self-Describing event field."""
+
+    vendor: str
+    name: str
+    path: str = ""
+    version: str | int = Field(default=1, pattern=r"^\d+-\d+-\d+$")
+
+    def __str__(self) -> str:
+        path = "" if not self.path else f":{self.path}"
+        return f"unstruct_event_{_clean_vendor(self.vendor)}_{_clean_name(self.name)}_{_clean_version(self.version)}{path}"
+
+
+class Column(RootModel[AtomicField | EntityProperty | SelfDescProperty]):
+    """Provide syntax sugar for creating Criterion instances from field references."""
+
+    @staticmethod
+    def atomic(field: AtomicField) -> "Column":
+        return Column(field)
+
+    @staticmethod
+    @wraps(SelfDescProperty)
+    def event(*args, **kwargs) -> "Column":
+        return Column(SelfDescProperty(*args, **kwargs))
+
+    @staticmethod
+    @wraps(EntityProperty)
+    def entity(*args, **kwargs) -> "Column":
+        return Column(EntityProperty(*args, **kwargs))
+
+    def __str__(self) -> str:
+        return str(self.root)
+
+    def __getitem__(self, key) -> "Column":
+        if isinstance(self.root, str):
+            raise KeyError()
+        return Column(self.root.model_copy(update={"path": key}))
+
+    def __eq__(self, other):
+        if isinstance(other, (str, int, float, bool, list)):
+            return _default_criteria(str(self), "=", other)
+        return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, (str, int, float, bool, list)):
+            return _default_criteria(str(self), "!=", other)
+        return NotImplemented
+
+    def __lt__(self, other):
+        if isinstance(other, (int, float)):
+            return _default_criteria(str(self), "<", other)
+        return NotImplemented
+
+    def __gt__(self, other):
+        if isinstance(other, (int, float)):
+            return _default_criteria(str(self), ">", other)
+        return NotImplemented
+
+    def __le__(self, other):
+        if isinstance(other, (int, float)):
+            return _default_criteria(str(self), "<=", other)
+        return NotImplemented
+
+    def __ge__(self, other):
+        if isinstance(other, (int, float)):
+            return _default_criteria(str(self), ">=", other)
+        return NotImplemented
+
+    def __mod__(self, other):
+        if isinstance(other, str):
+            return _default_criteria(str(self), "like", other)
+        return NotImplemented
+
+    def __lshift__(self, other):
+        if isinstance(other, list):
+            return _default_criteria(str(self), "in", other)
+        return NotImplemented

--- a/src/snowplow_signals/models/wrappers/criteria.py
+++ b/src/snowplow_signals/models/wrappers/criteria.py
@@ -1,0 +1,58 @@
+from ..model import Criteria as _Criteria
+from ..model import Criterion as _Criterion
+
+
+class Criteria(_Criteria):
+    def __and__(self, other):
+        if isinstance(other, _Criterion):
+            if self.all is not None:
+                return Criteria(all=[*self.all, other], any=None)
+        elif isinstance(other, _Criteria):
+            if self.all is not None and other.all is not None:
+                return Criteria(all=[*self.all, *other.all], any=None)
+            elif self.all is not None and other.any is not None and len(other.any) == 1:
+                return Criteria(all=[*self.all, *other.any], any=None)
+            elif (
+                self.any is not None
+                and len(self.any) == 1
+                and other.any is not None
+                and len(other.any) == 1
+            ):
+                return Criteria(all=[*self.any, *other.any], any=None)
+        return NotImplemented
+
+    def __or__(self, other):
+        if isinstance(other, _Criterion):
+            if self.any is not None:
+                return Criteria(all=None, any=[*self.any, other])
+        elif isinstance(other, _Criteria):
+            if self.any is not None and other.any is not None:
+                return Criteria(all=None, any=[*self.any, *other.any])
+            elif self.any is not None and other.all is not None and len(other.all) == 1:
+                return Criteria(all=None, any=[*self.any, *other.all])
+            elif (
+                self.all is not None
+                and len(self.all) == 1
+                and other.all is not None
+                and len(other.all) == 1
+            ):
+                return Criteria(all=None, any=[*self.all, *other.all])
+        return NotImplemented
+
+
+class Criterion(_Criterion):
+    def __and__(self, other):
+        if isinstance(other, _Criterion):
+            return Criteria(all=[self, other], any=None)
+        elif isinstance(other, _Criteria):
+            if other.all is not None:
+                return Criteria(all=[self, *other.all], any=None)
+        return NotImplemented
+
+    def __or__(self, other):
+        if isinstance(other, _Criterion):
+            return Criteria(all=None, any=[self, other])
+        elif isinstance(other, _Criteria):
+            if other.any is not None:
+                return Criteria(all=None, any=[self, *other.any])
+        return NotImplemented

--- a/test/models/test_sugar.py
+++ b/test/models/test_sugar.py
@@ -1,0 +1,118 @@
+import operator
+
+import pytest
+
+from snowplow_signals import Column, Criteria
+
+
+def test_atomic_field_references():
+    duid = Column("domain_userid")
+    duid2 = Column.atomic("domain_userid")
+    criteria = duid == "abc123"
+
+    assert duid.__dict__ == duid2.__dict__
+    assert isinstance(criteria, Criteria)
+    assert criteria.all is not None
+
+    criterion = criteria.all[0]
+    assert criterion.property == "domain_userid"
+    assert criterion.operator == "="
+    assert criterion.value == "abc123"
+
+
+def test_event_references():
+    sde = Column.event(vendor="com.example", name="event")
+    criteria = sde["test"] == "abc123"
+
+    assert isinstance(criteria, Criteria)
+    assert criteria.all is not None
+
+    criterion = criteria.all[0]
+    assert criterion.property == "unstruct_event_com_example_event_1:test"
+    assert criterion.operator == "="
+    assert criterion.value == "abc123"
+
+
+def test_entity_references():
+    sde = Column.entity(vendor="com.example", name="entity")
+    criteria = sde["test"] >= 0
+
+    assert isinstance(criteria, Criteria)
+    assert criteria.all is not None
+
+    criterion = criteria.all[0]
+    assert criterion.property == "contexts_com_example_entity_1[0].test"
+    assert criterion.operator == ">="
+    assert criterion.value == 0
+
+
+def test_operations():
+    duid = Column("domain_userid")
+
+    operations = {
+        "=": (operator.eq, "abc123"),
+        "!=": (operator.ne, "abc123"),
+        ">": (operator.gt, 0),
+        "<": (operator.lt, 0),
+        ">=": (operator.ge, 0),
+        "<=": (operator.le, 0),
+        "like": (operator.mod, "blah%123"),
+        "in": (operator.lshift, [0, 1, 2]),
+    }
+
+    for op, (fn, val) in operations.items():
+        criteria = fn(duid, val)
+
+        assert isinstance(criteria, Criteria)
+        assert criteria.all is not None
+
+        criterion = criteria.all[0]
+        assert criterion.property == "domain_userid"
+        assert criterion.operator == op
+        assert criterion.value == val
+
+    custom_ops = (duid << [0, 1, 2]) & (duid % "abc")
+    assert custom_ops.all is not None
+    assert len(custom_ops.all) == 2
+    assert custom_ops.all[0].operator == "in"
+    assert custom_ops.all[1].operator == "like"
+
+
+def test_criteria_type_checks():
+    sde = Column.entity(vendor="com.example", name="entity")
+
+    with pytest.raises(TypeError):
+        _ = sde["test"] > "a"
+
+
+def test_criteria_grouping():
+    duid = Column("domain_userid")
+    sid = Column("domain_sessionid")
+
+    criteria = (duid == "abc123") & (sid == "ses1")
+    assert isinstance(criteria, Criteria)
+    assert criteria.all is not None
+    assert criteria.any is None
+    assert len(criteria.all) == 2
+
+    criteria = (duid == "abc123") | (sid == "ses1")
+    assert isinstance(criteria, Criteria)
+    assert criteria.all is None
+    assert criteria.any is not None
+    assert len(criteria.any) == 2
+
+    all_criteria = (duid == "abc123") & (sid == "ses1")
+    any_criteria = (duid == "abc456") | (sid == "ses2")
+
+    with pytest.raises(TypeError):
+        _ = all_criteria | any_criteria  # we can't mix "all" and "any"
+    with pytest.raises(TypeError):
+        _ = any_criteria & all_criteria  # we can't mix "any" and "all"
+    with pytest.raises(TypeError):
+        _ = all_criteria | (sid == "")  # we can't demote a previous "all" to an "any"
+    with pytest.raises(TypeError):
+        _ = any_criteria & (sid == "")  # we can't promote a previous "any" to an "all"
+
+    # combining same types is fine
+    all_criteria &= all_criteria
+    any_criteria |= any_criteria


### PR DESCRIPTION
This aims to reduce verbosity when working with references to event data fields and building criteria from them, hiding some of the verbosity of the serializable DSL.

It adds the following new helper features:
- `Column`: an object that can reference a Snowplow column via `Column.atomic`, `Column.event`, and `Column.entity`; this helper handles building the `contexts_vendor_name_version:path` and similar strings used to reference values, so you can use the real schema's `self` values directly, similar to how you can for `Event` already in `View.events`.
- `Column` instances built by `.event()` or `.entity()` can have their sub-properties accessed via indexation; e.g. `str(Column.event(vendor="com.example", name="my_event")["property.path.to.value"]) == "unstruct_event_com_example_my_event_1:property.path.to.value"`
- Operations on `Column` instances directly produce `Criteria` values, so you can just do `Column.event(vendor="com.example", name="my_event")["value"] > 3` instead of `Criteria(all=[Criterion(property="unstruct_event_com_example_my_event_1:value", operator=">", value=3, property_syntax="snowflake")], any=None)`
- Indexing `Column`s produces new instances, so you can store references to specific events/entities for easier access: `my_event = Column.event(vendor="com.example", name="my_event"); v1 = my_event["v1"]; v2 = my_event["v2"]`
- Criteria can now be combined using the bitwise operators: `((v1 == "valueA") & (v2 > 2)) == Criteria(all=[Criterion(property="unstruct_event_com_example_my_event_1:v1", operator="=", value="valueA", property_syntax="snowflake"), Criterion(property="unstruct_event_com_example_my_event_1:v2", operator=">", value=2, property_syntax="snowflake")], any=None)`

Comparison from the docs:
Before:
```python
from snowplow_signals import Attribute, Event, Criteria, Criterion

products_added_to_cart_feature = Attribute(
    name="products_added_to_cart",
    type="string_list",
    events=[
        Event(
            vendor="com.snowplowanalytics.snowplow.ecommerce",
            name="snowplow_ecommerce_action",
            version="1-0-2",
        )
    ],
    aggregation="unique_list",
    property="contexts_com_snowplowanalytics_snowplow_ecommerce_product_1[0].name",
    criteria=Criteria(
        all=[
            Criterion(
                property="unstruct_event_com_snowplowanalytics_snowplow_ecommerce_snowplow_ecommerce_action_1:type",
                operator="=",
                value="add_to_cart",
            ),
        ],
    ),
)
```
After:
```python
from snowplow_signals import Attribute, Event, Column

products_added_to_cart_feature = Attribute(
    name="products_added_to_cart",
    type="string_list",
    events=[
        Event(
            vendor="com.snowplowanalytics.snowplow.ecommerce",
            name="snowplow_ecommerce_action",
            version="1-0-2",
        )
    ],
    aggregation="unique_list",
    property=str(Column.entity(vendor="com.snowplowanalytics.snowplow.ecommerce", name="product", path="name")),
    criteria=Column.event(vendor="com.snowplowanalytics.snowplow.ecommerce", name="snowplow_ecommerce_action", path="type") == "add_to_cart",
)
```

The new syntax is optional and should be non-breaking.
As a small perk, the new syntax will raise runtime errors when using operators with the wrong type of values rather than waiting for the API to report the error.
If you like the approach I will follow up with similar for Intervention definitions, LMKWYT.

Had to touch some file formatting to make pre-commit happy.