### PR TITLE
[AISP-566] Fix None attributes sent on API

### DIFF
--- a/src/snowplow_signals/attributes_client.py
+++ b/src/snowplow_signals/attributes_client.py
@@ -49,7 +49,7 @@ class AttributesClient:
         response = self.api_client.make_request(
             method="POST",
             endpoint="get-online-attributes",
-            data=request.model_dump(mode="json"),
+            data=request.model_dump(mode="json", exclude_none=True),
         )
         return _format_get_attributes_response(GetAttributesResponse(data=response))
 


### PR DESCRIPTION
For the API requests to look a bit cleaner and also be strict in what we emit, I added the removal of None fields from the payload of online-attributes.