### PR TITLE
Feature/aisp 684 allow property wrappers on attribute property

### DIFF
--- a/src/snowplow_signals/models/__init__.py
+++ b/src/snowplow_signals/models/__init__.py
@@ -1,7 +1,7 @@
+from .attribute import Attribute
 from .criterion_wrapper import Criterion
 from .get_attributes_response import GetAttributesResponse
 from .interventions import RuleIntervention
-from .model import AttributeInput as Attribute
 from .model import (
     AttributeOutput,
     BatchSource,

--- a/src/snowplow_signals/models/attribute.py
+++ b/src/snowplow_signals/models/attribute.py
@@ -1,0 +1,29 @@
+from typing import Annotated
+
+from pydantic import BeforeValidator, Field
+
+from .model import AttributeInput
+from .property_wrappers.atomic import AtomicProperty
+from .property_wrappers.entity import EntityProperty
+from .property_wrappers.event import EventProperty
+
+
+def convert_property_wrapper_to_string(
+    value: EventProperty | EntityProperty | AtomicProperty | None,
+) -> str | None:
+    if isinstance(value, str):
+        return value
+
+    if value is None:
+        return None
+
+    if isinstance(value, (EventProperty, EntityProperty, AtomicProperty)):
+        return value._to_api_property()
+
+    raise ValueError(
+        f"property must be a string, wrapper object, or None, got {type(value)}"
+    )
+
+
+class Attribute(AttributeInput):
+    property: Annotated[str | EventProperty | EntityProperty | AtomicProperty | None, BeforeValidator(convert_property_wrapper_to_string)] = Field(default=None, description="The property on the event or entity to use in the aggregation.")  # type: ignore[assignment]

--- a/test/models/test_attribute.py
+++ b/test/models/test_attribute.py
@@ -1,6 +1,14 @@
 import pytest
 
-from snowplow_signals import Attribute, Criteria, Criterion, Event
+from snowplow_signals import (
+    AtomicProperty,
+    Attribute,
+    Criteria,
+    Criterion,
+    EntityProperty,
+    Event,
+    EventProperty,
+)
 
 
 class TestValidAttributes:
@@ -160,3 +168,69 @@ class TestInvalidAttributes:
                     ],
                 ),
             )
+
+
+class TestValidPropertyWrappers:
+    def test_valid_entity_property(self):
+        attribute = Attribute(
+            name="max_cart_value",
+            type="int32",
+            events=[
+                Event(
+                    vendor="com.snowplowanalytics.snowplow.ecommerce",
+                    name="snowplow_ecommerce_action",
+                    version="1-0-2",
+                )
+            ],
+            aggregation="max",
+            property=EntityProperty(
+                vendor="com.snowplowanalytics.snowplow.ecommerce",
+                name="cart",
+                major_version=1,
+                path="total_value",
+            ),
+        )
+        assert (
+            attribute.property
+            == "contexts_com_snowplowanalytics_snowplow_ecommerce_cart_1[0].total_value"
+        )
+
+    def test_valid_event_property(self):
+        attribute = Attribute(
+            name="first_button_click_label",
+            type="string",
+            events=[
+                Event(
+                    vendor="com.snowplowanalytics.snowplow",
+                    name="button_click",
+                    version="1-0-0",
+                )
+            ],
+            aggregation="first",
+            property=EventProperty(
+                vendor="com.snowplowanalytics.snowplow",
+                name="button_click",
+                major_version=1,
+                path="label",
+            ),
+        )
+        assert (
+            attribute.property
+            == "unstruct_event_com_snowplowanalytics_snowplow_button_click_1:label"
+        )
+
+    def test_valid_atomic_property(self):
+        attribute = Attribute(
+            name="last_mkt_source",
+            type="string",
+            events=[
+                Event(
+                    vendor="com.snowplowanalytics.snowplow",
+                    name="link_click",
+                    version="1-0-1",
+                )
+            ],
+            aggregation="last",
+            property=AtomicProperty(name="mkt_source"),
+        )
+        assert attribute.property == "mkt_source"


### PR DESCRIPTION
Allow for property wrappers to be used in the `Attribute.property` . I have not found a way to fix VSCode intellisense to show correct attributes on hover for the property. _This is also true for other attributes but if someone has a better fix, please let me know_

_(Expecting the first commit to go into the release first so then I just rebase)_