### PR TITLE
Reduce threads

### DIFF
--- a/integration_tests/integration_test/ci/profiles.yml
+++ b/integration_tests/integration_test/ci/profiles.yml
@@ -17,7 +17,7 @@ integration_tests:
       port: "{{ env_var('POSTGRES_TEST_PORT') | as_number }}"
       dbname: "{{ env_var('POSTGRES_TEST_DBNAME') }}"
       schema: "gh_sp_batch_autogen_dbt_{{ env_var('SCHEMA_SUFFIX') }}"
-      threads: 4
+      threads: 1
 
     redshift:
       type: redshift
@@ -27,7 +27,7 @@ integration_tests:
       dbname: "{{ env_var('REDSHIFT_TEST_DBNAME') }}"
       port: "{{ env_var('REDSHIFT_TEST_PORT') | as_number }}"
       schema: "gh_sp_batch_autogen_dbt_{{ env_var('SCHEMA_SUFFIX') }}"
-      threads: 4
+      threads: 1
 
     bigquery:
       type: bigquery
@@ -35,7 +35,7 @@ integration_tests:
       project: "{{ env_var('BIGQUERY_TEST_DATABASE') }}"
       location: "{{ env_var('BIGQUERY_LOCATION') }}"
       schema: "gh_sp_batch_autogen_dbt_{{ env_var('SCHEMA_SUFFIX') }}"
-      threads: 4
+      threads: 1
       keyfile_json:
         type: "{{ env_var('BIGQUERY_SERVICE_TYPE') }}"
         project_id: "{{ env_var('BIGQUERY_SERVICE_PROJECT_ID') }}"
@@ -57,7 +57,7 @@ integration_tests:
       database: "{{ env_var('SNOWFLAKE_TEST_DATABASE') }}"
       warehouse: "{{ env_var('SNOWFLAKE_TEST_WAREHOUSE') }}"
       schema: "gh_sp_batch_autogen_dbt_{{ env_var('SCHEMA_SUFFIX') }}"
-      threads: 4
+      threads: 1
 
     databricks:
       type: databricks
@@ -65,7 +65,7 @@ integration_tests:
       host: "{{ env_var('DATABRICKS_TEST_HOST') }}"
       http_path: "{{ env_var('DATABRICKS_TEST_HTTP_PATH') }}"
       token: "{{ env_var('DATABRICKS_TEST_TOKEN') }}"
-      threads: 4
+      threads: 1
 
     spark_iceberg:
       type: spark


### PR DESCRIPTION
Attempting to stabilize flaky integration tests: 

**Snowflake:**
 `Object '***.GH_SP_BATCH_AUTOGEN_DBT_1_SNPLW_BATCH_AUTOGEN_INT_TESTS.SNOWPLOW_BATCH_AUTOGEN_ATTRIBUTES_EXPECTED' does not exist or not authorized.`
**Bigquery:**
 `Not found: Dataset ***:gh_sp_batch_autogen_dbt_1_scratch was not found in location ***`