### PR TITLE
Fix AttributeGroup.get_attributes() to also consider the fields when constructing a request to retrieve attribute values

### DIFF
--- a/src/snowplow_signals/models/attribute_group.py
+++ b/src/snowplow_signals/models/attribute_group.py
@@ -48,12 +48,17 @@ class AttributeGroup(AttributeGroupInput):
             The attributes for the attribute group.
         """
 
+        attributes = [
+            attribute.name
+            for attribute in (self.attributes or []) + (self.fields or [])
+        ]
+
         return signals.get_group_attributes(
             name=self.name,
             version=self.version,
             attribute_key=self.attribute_key.name,
             identifier=identifier,
-            attributes=[attribute.name for attribute in self.attributes],
+            attributes=attributes,
         )
 
 


### PR DESCRIPTION
The `AttributeGroup.get_attributes()` function did not return attribute values for fields in external batch groups.