### PR TITLE
Bugfix/aisp 749/fix duplicate columns

### DIFF
--- a/src/snowplow_signals/batch_autogen/templates/filtered_events_this_run.j2
+++ b/src/snowplow_signals/batch_autogen/templates/filtered_events_this_run.j2
@@ -20,18 +20,17 @@ with prep as (
         {{ var('snowplow__attribute_key', 'domain_userid') }} as attribute_key,
         {% endraw %}
         
-        {%- if not properties | selectattr('alias', 'equalto', 'derived_tstamp') | list %}
+        date(derived_tstamp) as event_date,
+        
+        {%- if not properties | selectattr('full_path', 'equalto', 'derived_tstamp') | list %}
                 derived_tstamp,
-                date(derived_tstamp) as event_date,
-        {%- else %}
-                date(derived_tstamp) as event_date,
         {%- endif %}
         
-        {%- if not properties | selectattr('alias', 'equalto', 'load_tstamp') | list %}
+        {%- if not properties | selectattr('full_path', 'equalto', 'load_tstamp') | list %}
                 load_tstamp,
         {%- endif %}
         
-        {%- if not properties | selectattr('alias', 'equalto', 'event_name') | list %}
+        {%- if not properties | selectattr('full_path', 'equalto', 'event_name') | list %}
                 event_name,
         {%- endif %}
         

--- a/test/auto_gen/__snapshots__/test_snapshots_bigquery.ambr
+++ b/test/auto_gen/__snapshots__/test_snapshots_bigquery.ambr
@@ -2132,8 +2132,9 @@
               event_id,
               {{ var('snowplow__attribute_key', 'domain_userid') }} as attribute_key,
               
+              
+              date(derived_tstamp) as event_date,
                       derived_tstamp,
-                      date(derived_tstamp) as event_date,
                       load_tstamp,
                       event_name,
                   

--- a/test/auto_gen/__snapshots__/test_snapshots_snowflake.ambr
+++ b/test/auto_gen/__snapshots__/test_snapshots_snowflake.ambr
@@ -2132,8 +2132,9 @@
               event_id,
               {{ var('snowplow__attribute_key', 'domain_userid') }} as attribute_key,
               
+              
+              date(derived_tstamp) as event_date,
                       derived_tstamp,
-                      date(derived_tstamp) as event_date,
                       load_tstamp,
                       event_name,
                   


### PR DESCRIPTION
PR to:

1. Amend the jinja template `filtered_events_this_run.j2` to not select the following columns twice from `base_events_this_run` if any of these columns are available as a property:

    - derived_tstamp
    - date(derived_tstamp) as event_date
    - load_tstamp
    - event_name

2. Also updated the pytest snapshot

3. Has been tested locally by:
     - Adding attribute `event_name` to  `integration_test_view_snowflake.json`
     - Amending the pytest snapshot `test_snapshots_snowflake.ambr`
     - Successfully running: `bash integration_tests/test_E2E.sh -d snowflake`