### PR TITLE
Add pre-release workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,80 @@
+name: Pre-release Python Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version type to increment"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: "patch"
+      prerelease_type:
+        description: "Pre-release type"
+        required: true
+        type: choice
+        options:
+          - rc
+          - alpha
+          - beta
+        default: "rc"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v3
+
+      - name: Install dependencies
+        run: poetry install --extras "batch-engine"
+
+      - name: Run tests
+        run: poetry run pytest
+
+      - name: Get current version
+        id: version
+        run: |
+          CURRENT_VERSION=$(poetry version -s)
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Calculate new version
+        id: new_version
+        run: |
+          CURRENT_VERSION=${{ steps.version.outputs.current_version }}
+          VERSION_TYPE=${{ github.event.inputs.version_type }}
+          PRERELEASE_TYPE=${{ github.event.inputs.prerelease_type }}
+          NEW_VERSION=$(poetry run python scripts/version.py "$CURRENT_VERSION" "$VERSION_TYPE" "$PRERELEASE_TYPE")
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update version
+        run: |
+          poetry version ${{ steps.new_version.outputs.new_version }}
+
+      - name: Create and push tag
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add pyproject.toml
+          git commit -m "chore: pre-release v${{ steps.new_version.outputs.new_version }}"
+          git tag -a "v${{ steps.new_version.outputs.new_version }}" -m "Pre-release v${{ steps.new_version.outputs.new_version }}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "v${{ steps.new_version.outputs.new_version }}"
+
+      - name: Build package
+        run: poetry build
+
+      - name: Publish to PyPI
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: poetry publish --username __token__ --password $PYPI_API_TOKEN

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -4,6 +4,7 @@ import semver
 from typing import Literal
 
 VersionType = Literal["patch", "minor", "major"]
+PrereleaseType = Literal["rc", "alpha", "beta"]
 
 
 def bump_version(current_version: str, version_type: VersionType) -> str:
@@ -31,13 +32,70 @@ def bump_version(current_version: str, version_type: VersionType) -> str:
     return str(new_version)
 
 
+def bump_prerelease(
+    current_version: str,
+    prerelease_type: PrereleaseType,
+    version_bump: VersionType = "patch",
+) -> str:
+    """
+    Bump to a pre-release version.
+
+    If current version is stable (e.g., "1.2.3"), bumps to next version with pre-release.
+    If current version is already a pre-release, increments the pre-release number.
+
+    Args:
+        current_version: Current version string (e.g., "1.2.3" or "1.2.4-rc1")
+        prerelease_type: Type of pre-release ("rc", "alpha", "beta")
+        version_bump: Version component to bump if starting from stable ("patch", "minor", "major")
+
+    Returns:
+        New pre-release version string (format: X.Y.Z-rc1)
+    """
+    version = semver.VersionInfo.parse(current_version)
+
+    # If already a pre-release, increment it
+    if version.prerelease:
+        # Parse existing prerelease to increment number
+        import re
+
+        match = re.match(r"([a-z]+)(\d+)", version.prerelease)
+        if match:
+            prefix, num = match.groups()
+            new_prerelease = f"{prefix}{int(num) + 1}"
+        else:
+            # Fallback if format is unexpected
+            new_prerelease = f"{prerelease_type}1"
+
+        new_version = version.replace(prerelease=new_prerelease)
+    else:
+        # Bump to next version with pre-release identifier
+        if version_bump == "patch":
+            new_version = version.bump_patch()
+        elif version_bump == "minor":
+            new_version = version.bump_minor()
+        elif version_bump == "major":
+            new_version = version.bump_major()
+        else:
+            raise ValueError(f"Invalid version type: {version_bump}")
+
+        # Add pre-release identifier
+        new_version = new_version.replace(prerelease=f"{prerelease_type}1")
+
+    return str(new_version)
+
+
 def main():
-    if len(sys.argv) != 3:
-        print("Usage: python version.py <current_version> <version_type>")
+    if len(sys.argv) < 3:
+        print(
+            "Usage: python version.py <current_version> <version_type> [prerelease_type]"
+        )
+        print("  version_type: patch, minor, major")
+        print("  prerelease_type (optional): rc, alpha, beta")
         sys.exit(1)
 
     current_version = sys.argv[1]
     version_type_str = sys.argv[2]
+    prerelease_type_str = sys.argv[3] if len(sys.argv) > 3 else None
 
     try:
         if version_type_str not in ("patch", "minor", "major"):
@@ -45,7 +103,19 @@ def main():
                 f"Invalid version type: {version_type_str}. Must be one of: patch, minor, major"
             )
         version_type: VersionType = version_type_str  # type: ignore
-        new_version = bump_version(current_version, version_type)
+
+        if prerelease_type_str:
+            if prerelease_type_str not in ("rc", "alpha", "beta"):
+                raise ValueError(
+                    f"Invalid prerelease type: {prerelease_type_str}. Must be one of: rc, alpha, beta"
+                )
+            prerelease_type: PrereleaseType = prerelease_type_str  # type: ignore
+            new_version = bump_prerelease(
+                current_version, prerelease_type, version_type
+            )
+        else:
+            new_version = bump_version(current_version, version_type)
+
         print(new_version)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -63,8 +63,7 @@ def bump_prerelease(
             prefix, num = match.groups()
             new_prerelease = f"{prefix}{int(num) + 1}"
         else:
-            # Fallback if format is unexpected
-            new_prerelease = f"{prerelease_type}1"
+            raise ValueError("Invalid pre-release format")
 
         new_version = version.replace(prerelease=new_prerelease)
     else:


### PR DESCRIPTION
Adds a workflow to be able to make `-rcX` releases from a given branch. Works similar as the main release workflow, but targets a certain branch.

Need to integrate it into the main branch to be able to test it out.