### PR TITLE
ci: add implement + claude-code workflows for the agent pipeline

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,87 @@
+name: Claude Code
+
+# Responds to `@claude` mentions in PR / issue comments and review threads.
+#
+# Primary use case: amending an in-flight PR during review — engineers
+# comment with corrections, follow-up scope changes, or answers to
+# questions raised by the bot's draft PR, and tag `@claude`. The bot
+# pulls the PR context, makes the requested change on the same branch,
+# and replies inline.
+#
+# Mirrors the equivalent workflow in `signals-monorepo` (and the other
+# Snowplow agent-toolable repos), using the same `snowplow-claude-review`
+# GitHub App.
+#
+# Required secrets (org-inherited from snowplow-incubator):
+#   - CLAUDE_REVIEW_APP_ID
+#   - CLAUDE_REVIEW_APP_PRIVATE_KEY
+# Required secrets (repo):
+#   - ANTHROPIC_API_KEY
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Ignore events authored by bots so automated comments posted by other
+    # workflows (e.g. the Implement bot's "draft PR created" message) can't
+    # accidentally trigger a Claude run — even if their body happens to
+    # contain "@claude".
+    if: |
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_REVIEW_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Use the app token so branches/PRs Claude creates trigger downstream
+          # CI (the default GITHUB_TOKEN would suppress those workflows).
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          additional_permissions: |
+            actions: read
+          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue comment:*),Bash(poetry:*)"'

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1,0 +1,73 @@
+name: Implement
+
+# Triggered when the `implement` label is added to a GitHub issue.
+#
+# Issues come from the refine-agent dispatcher (in
+# `snowplow-incubator/refine-agent`), which builds a self-contained body
+# carrying the relevant slice of the merged plan. This workflow hands
+# the issue context to `anthropics/claude-code-action`, which:
+#
+#   - reads the issue title and body as the spec,
+#   - reads CLAUDE.md (including the "Implementing tickets" section),
+#   - implements the change with `poetry` for build / lint / test,
+#   - opens a draft PR with `[AISP-XXX]` in the title and `Closes #NNN`
+#     in the body,
+#   - replies on the issue with the PR URL.
+#
+# Required secrets (org-inherited from snowplow-incubator):
+#   - CLAUDE_REVIEW_APP_ID
+#   - CLAUDE_REVIEW_APP_PRIVATE_KEY
+# Required secrets (repo):
+#   - ANTHROPIC_API_KEY
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement:
+    if: github.event.label.name == 'implement'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_REVIEW_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Use the app token so branches/PRs Claude creates trigger downstream
+          # CI (the default GITHUB_TOKEN would suppress those workflows).
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          additional_permissions: |
+            actions: read
+          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue comment:*),Bash(poetry:*)"'

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -70,4 +70,12 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           additional_permissions: |
             actions: read
+          # The `implement` label on this issue IS the trigger. Without
+          # this the action looks for `@claude` in the body, finds
+          # nothing, and exits silently.
+          label_trigger: implement
+          # The dispatching issue is authored by the snowplow-claude-review
+          # GitHub App. Without this opt-in the action filters bot-authored
+          # events to prevent recursion.
+          allowed_bots: '*'
           claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue comment:*),Bash(poetry:*)"'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# Snowplow Signals Python SDK — Agent Entry Point
+
+This is the Python SDK for Snowplow Signals — a client library for defining attribute groups, registering them with the Signals API, and reading attributes / interventions at inference time.
+
+## Components at a glance
+
+| Path | Purpose |
+|---|---|
+| `src/snowplow_signals/` | The SDK package — public API, models, batch + online clients |
+| `src/snowplow_signals/models/` | Pydantic models generated from the Signals OpenAPI |
+| `test/` | Unit tests (pytest) |
+| `integration_tests/` | End-to-end tests against a live Signals API |
+| `local_testing/` | Local-dev fixtures and scripts |
+
+## Build system — Poetry
+
+```bash
+# Setup
+poetry install --with dev
+poetry run pre-commit install
+
+# Tests
+poetry run pytest                   # all
+poetry run pytest test/<file>       # subset
+
+# Format + lint
+poetry run black .
+poetry run isort .
+
+# Build
+poetry build
+```
+
+Python ≥ 3.11. Code style: [black](https://github.com/psf/black). Tests: pytest.
+
+## What Claude must never do
+
+1. **Never modify existing test assertions** — assertions express human-defined correctness; only the developer changes them.
+2. **Never change public API shape** implicitly — class signatures, method names, parameter types, and return types are contracts with SDK users.
+3. **Never edit `src/snowplow_signals/models/model.py` by hand** — it's generated from the Signals API's OpenAPI spec; regenerate via the documented tooling instead.
+4. **Never commit secrets** — no API keys, tokens, or credentials in any file.
+5. **Never keep unused or dead code** unless explicitly instructed.
+
+## Implementing tickets
+
+When you're triggered by the `implement` label on a GitHub issue (or asked to implement an issue / Jira ticket locally), the issue body is the spec — read it carefully before anything else.
+
+Then:
+
+1. Read this file. If the change touches a specific area (models, batch client, online client), skim that area's existing code to match its patterns before editing.
+2. Implement the change as described in the issue body. Don't deviate from its file-level intent. If you find an error in it, note the deviation in the PR description.
+3. Keep changes minimal and focused. Don't refactor unrelated code.
+4. Add or modify tests for every new feature or bug fix. Tests live in `test/` (unit) and `integration_tests/` (e2e).
+5. If you discover a real architectural blocker the spec didn't anticipate, stop and post a comment on the issue. Don't guess.
+
+Before opening the PR:
+
+- `poetry run black .` — formatting
+- `poetry run isort .` — import order
+- `poetry run pytest` — tests pass
+
+PR shape (matches this repo's `CONTRIBUTING.md`):
+
+- **Branch**: `feature/aisp-<key>-<short-description>` (lowercase, e.g. `feature/aisp-1234-add-foo`). Use `fix/`, `chore/`, etc. as appropriate.
+- **Commits**: prefix with the Jira key in brackets, e.g. `[AISP-123] Add foo support`.
+- **PR title**: same `[AISP-XXX] Description` prefix. If a GitHub issue number is provided, append `(closes #NNN)`.
+- **PR body**: Summary, `Closes #NNN`, Changes, Testing.
+
+See `CONTRIBUTING.md` for the broader workflow (versioning, release process, etc.).


### PR DESCRIPTION
## Summary

Adds the two CI workflows that wire this repo into the Snowplow agent pipeline:

1. **`implement.yml`** — fires on `issues:labeled` with `implement`. Issues come from the refine-agent dispatcher in [refine-agent](https://github.com/snowplow-incubator/refine-agent), which builds a self-contained issue body from the merged plan. The workflow picks it up and opens a draft PR.
2. **`claude-code.yml`** — responds to `@claude` mentions in PR / issue comments and review threads. Lets engineers ask the bot for inline amendments to an in-flight PR.

Same shape as the equivalent workflows in `signals-monorepo`. Python SDK build system: **poetry**.

## Changes

- **`.github/workflows/implement.yml`** (new) — App token mint → checkout → build-system setup → `anthropics/claude-code-action` with the Python SDK's tool allowlist.
- **`.github/workflows/claude-code.yml`** (new) — same App token + build-system setup, different trigger set (`issue_comment` / `pull_request_review_comment` / `pull_request_review` / `issues` with `@claude` in body).
- **`CLAUDE.md`** — new or extended with an "Implementing tickets" section matching this repo's existing `CONTRIBUTING.md` conventions.

## Required secrets

| Name | Where it comes from |
|---|---|
| `CLAUDE_REVIEW_APP_ID` | Org-inherited |
| `CLAUDE_REVIEW_APP_PRIVATE_KEY` | Org-inherited |
| `ANTHROPIC_API_KEY` | Per-repo secret (needs to be added before either workflow works) |

## Test plan

- [ ] Lint: `yamllint` + `actionlint` (clean for both workflows).
- [ ] Confirm `ANTHROPIC_API_KEY` is set on the repo before merging.
- [ ] End-to-end `implement`: from refine-agent, dispatch an implement that touches this repo. Confirm a labelled GitHub issue appears here and the workflow opens a draft PR.
- [ ] End-to-end `@claude`: open a PR (any PR will do), comment `@claude please rename foo to bar`, confirm the bot makes the change on the branch.

## Related

- Template: `snowplow-incubator/signals-monorepo#533`.
- Dispatcher: [`snowplow-incubator/refine-agent`](https://github.com/snowplow-incubator/refine-agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)