### PR TITLE
feat: [AISP-1507] add "changed" operator to intervention criteria

### DIFF
--- a/src/snowplow_signals/models/model.py
+++ b/src/snowplow_signals/models/model.py
@@ -869,6 +869,7 @@ class SignalsApiModelsInterventionCriterionCriterion(BaseModel):
         "not in",
         "is null",
         "is not null",
+        "changed",
     ] = Field(
         ...,
         description="The operator used to compare the attribute to the value.",

--- a/test/models/test_interventions.py
+++ b/test/models/test_interventions.py
@@ -37,3 +37,36 @@ def test_view_with_owner_passes_validation():
         target_attribute_keys=[LinkAttributeKey(name="domain_sessionid")],
     )
     assert view_with_owner.owner == "test@example.com"
+
+
+def test_changed_operator_criterion_without_value():
+    """The 'changed' operator is accepted and needs no value."""
+    criterion = InterventionCriterion(
+        attribute="sample_ecommerce_stream_features:add_to_cart_events_count",
+        operator="changed",
+    )
+    assert criterion.operator == "changed"
+    assert criterion.value is None
+
+
+def test_changed_operator_in_rule_intervention():
+    """A RuleIntervention can use the 'changed' operator in its criteria."""
+    intervention = RuleIntervention(
+        name="test_intervention",
+        owner="test@example.com",
+        criteria=InterventionCriterion(
+            attribute="sample_ecommerce_stream_features:add_to_cart_events_count",
+            operator="changed",
+        ),
+        target_attribute_keys=[LinkAttributeKey(name="domain_sessionid")],
+    )
+    assert intervention.criteria.operator == "changed"
+
+
+def test_invalid_operator_raises_validation_error():
+    """An unknown operator is rejected by the criterion model."""
+    with pytest.raises(ValidationError):
+        InterventionCriterion(
+            attribute="sample_ecommerce_stream_features:add_to_cart_events_count",
+            operator="not_a_real_operator",
+        )


### PR DESCRIPTION
## Summary

Adds the new **`changed`** operator to the intervention criterion model, exposing it through the Python SDK. `changed` fires an intervention every time a referenced attribute's value changes (rather than only the first time a condition becomes true). Like the null operators, it takes no value.

Backend support landed in AISP-1503 (Signals API). Part of epic AISP-1504.

## Changes

- **`src/snowplow_signals/models/model.py`** — the intervention Criterion (`SignalsApiModelsInterventionCriterionCriterion`, exposed publicly as `InterventionCriterion`) operator `Literal` now includes `"changed"`. This matches regenerating the model from the updated API OpenAPI contract; the addition is a single enum member, with no unrelated model drift.
- **`test/models/test_interventions.py`** — tests for a bare `changed` criterion (no value), `changed` inside a `RuleIntervention`, and rejection of an unknown operator.

## Testing

- `poetry run pytest test/` — all 85 tests pass (no snapshot drift).
- `black --check` and `isort --check-only` clean on the changed files.

## Notes

- **Model is generated** via `datamodel-code-generator` from the API's OpenAPI spec (see `src/snowplow_signals/models/models/README.md`). Since `changed` is a single, well-defined enum addition already present in the API contract, this is a surgical edit equivalent to a regeneration of that field — avoiding unrelated churn from regenerating the whole spec against the current API.
- **No CHANGELOG or version bump** here: per `CONTRIBUTING.md`, those are handled in the release PR (`release/x.x.x`), consistent with how prior feature PRs (e.g. AISP-1520) were merged.
- `changed` is intervention-only, so the `Criterion` wrapper (which wraps the separate *view/attribute-group* criterion) is intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)