### PR TITLE
fix(release): make version script tolerant of PEP 440 input

### DIFF
--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,10 +1,29 @@
 #!/usr/bin/env python3
+import re
 import sys
 import semver
 from typing import Literal
 
 VersionType = Literal["patch", "minor", "major"]
 PrereleaseType = Literal["rc", "alpha", "beta"]
+
+
+def normalize_to_semver(version: str) -> str:
+    """
+    Normalize a PEP 440 version string to SemVer.
+
+    Poetry stores versions in PEP 440 form (e.g. "0.4.7rc1"), but semver
+    requires a hyphen before the pre-release identifier ("0.4.7-rc1"). This
+    inserts the missing hyphen so a PEP 440 pre-release parses cleanly.
+    Already-SemVer and stable versions pass through unchanged.
+
+    Args:
+        version: Version string in PEP 440 or SemVer form
+
+    Returns:
+        SemVer-compatible version string
+    """
+    return re.sub(r"([0-9])(rc|alpha|beta|a|b)", r"\1-\2", version)
 
 
 def bump_version(current_version: str, version_type: VersionType) -> str:
@@ -18,7 +37,7 @@ def bump_version(current_version: str, version_type: VersionType) -> str:
     Returns:
         New version string
     """
-    version = semver.VersionInfo.parse(current_version)
+    version = semver.VersionInfo.parse(normalize_to_semver(current_version))
 
     if version_type == "patch":
         new_version = version.bump_patch()
@@ -51,7 +70,7 @@ def bump_prerelease(
     Returns:
         New pre-release version string (format: X.Y.Z-rc1)
     """
-    version = semver.VersionInfo.parse(current_version)
+    version = semver.VersionInfo.parse(normalize_to_semver(current_version))
 
     # If already a pre-release, increment it
     if version.prerelease:

--- a/test/test_version_script.py
+++ b/test/test_version_script.py
@@ -1,0 +1,57 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+)
+
+from version import (  # noqa: E402
+    bump_prerelease,
+    bump_version,
+    normalize_to_semver,
+)
+
+
+class TestNormalizeToSemver:
+    @pytest.mark.parametrize(
+        "pep440,expected",
+        [
+            ("0.4.7rc1", "0.4.7-rc1"),
+            ("0.5.0beta2", "0.5.0-beta2"),
+            ("1.0.0alpha1", "1.0.0-alpha1"),
+        ],
+    )
+    def test_inserts_hyphen_for_pep440_prerelease(self, pep440, expected):
+        assert normalize_to_semver(pep440) == expected
+
+    @pytest.mark.parametrize(
+        "version",
+        ["0.4.7-rc1", "0.5.0-beta2", "1.0.0", "2.3.4"],
+    )
+    def test_is_idempotent_for_semver_and_stable(self, version):
+        assert normalize_to_semver(version) == version
+
+
+class TestBumpPrerelease:
+    def test_increments_from_pep440_prerelease(self):
+        # Regression: Poetry writes "0.4.7rc1"; must not raise "not valid SemVer".
+        assert bump_prerelease("0.4.7rc1", "rc") == "0.4.7-rc2"
+
+    def test_increments_from_semver_prerelease(self):
+        assert bump_prerelease("0.4.7-rc1", "rc") == "0.4.7-rc2"
+
+    def test_starts_prerelease_from_stable(self):
+        assert bump_prerelease("0.4.6", "rc") == "0.4.7-rc1"
+
+    def test_respects_version_bump_from_stable(self):
+        assert bump_prerelease("0.4.6", "beta", "minor") == "0.5.0-beta1"
+
+
+class TestBumpVersion:
+    def test_bump_from_pep440_prerelease(self):
+        assert bump_version("0.4.7rc1", "patch") == "0.4.8"
+
+    def test_bump_patch_from_stable(self):
+        assert bump_version("0.4.6", "patch") == "0.4.7"


### PR DESCRIPTION
## Problem

The prerelease workflow failed with:

```text
Error: 0.4.7rc1 is not valid SemVer string
```

`scripts/version.py` parses the current version with `semver`, which requires a hyphen before the prerelease identifier (`0.4.7-rc1`). But Poetry normalizes versions to **PEP 440** form when writing `pyproject.toml`, so `poetry version 0.4.7-rc1` stores `0.4.7rc1` (no hyphen). On the *next* prerelease bump, the workflow reads `0.4.7rc1` back, `semver.VersionInfo.parse` rejects it, and the release breaks.

The pipeline was self-inconsistent: it *writes* PEP 440 but *reads* SemVer. It worked for the first rc (starting from a stable version) and broke on the second.

## Fix

Normalize PEP 440 prerelease strings to SemVer inside `version.py` (`normalize_to_semver`) before parsing, so the script tolerates whatever form Poetry writes. Stable and already-SemVer versions pass through unchanged (idempotent).

Adds `test/test_version_script.py` covering the regression (`0.4.7rc1` → `0.4.7-rc2`) plus normalization, prerelease increment, and stable bumps.

## Note

A minimal hotfix (a `sed` normalization in the workflow) was applied directly on the `release/0.4.7-rc2` branch to unblock the in-flight release. This PR is the proper, tested fix in the script itself; the workflow hotfix can be dropped once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)